### PR TITLE
Enable converting Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 This simple tool can be used to convert markdown written text to (MoinMoin)[https://moinmo.in/] wiki syntax. 
 
+## build
+Running the following will create a docker container tagged `malanius/md2moin-web:latest`:
+```
+mvn clean package
+```
+A .jar containing the application (for deployment with tomcat/catalina) resides in
+```
+md2moin-web/target/md2moin-web-1.0-SNAPSHOT.jar
+```
+
 ## AWS
 
 Application currently runs on AWS Elastic Beanstalk environment with Docker.

--- a/md2moin-core/src/main/java/net/malanius/md2moin/core/ConverterImpl.java
+++ b/md2moin-core/src/main/java/net/malanius/md2moin/core/ConverterImpl.java
@@ -6,6 +6,7 @@ import net.malanius.md2moin.core.emphasis.EmphasisConverter;
 import net.malanius.md2moin.core.headers.HeaderConverter;
 import net.malanius.md2moin.core.lists.ListConverter;
 import net.malanius.md2moin.core.tables.TableConverter;
+import net.malanius.md2moin.core.links.LinkConverter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -18,14 +19,16 @@ public class ConverterImpl implements Converter {
     private final ListConverter listConverter;
     private final CodeBlockConverter codeblockConverter;
     private final TableConverter tableConverter;
+    private final LinkConverter linkConverter;
 
     @Autowired
-    public ConverterImpl(EmphasisConverter emphasisConverter, HeaderConverter headerConverter, ListConverter listConverter, CodeBlockConverter codeBlockConverter, TableConverter tableConverter) {
+    public ConverterImpl(EmphasisConverter emphasisConverter, HeaderConverter headerConverter, ListConverter listConverter, CodeBlockConverter codeBlockConverter, TableConverter tableConverter, LinkConverter linkConverter) {
         this.emphasisConverter = emphasisConverter;
         this.headerConverter = headerConverter;
         this.listConverter = listConverter;
         this.codeblockConverter = codeBlockConverter;
         this.tableConverter = tableConverter;
+        this.linkConverter = linkConverter;
     }
 
     @Override
@@ -50,6 +53,7 @@ public class ConverterImpl implements Converter {
         converted = codeblockConverter.convertCodeBlock(converted);
         converted = codeblockConverter.convertInlineCode(converted);
         converted = tableConverter.convertTable(converted);
+        converted = linkConverter.convertLink(converted);
         return converted;
     }
 

--- a/md2moin-core/src/main/java/net/malanius/md2moin/core/links/LinkConstants.java
+++ b/md2moin-core/src/main/java/net/malanius/md2moin/core/links/LinkConstants.java
@@ -3,7 +3,7 @@ package net.malanius.md2moin.core.links;
 final class LinkConstants {
 
     static final String LINK_FIND = "\\[(.+?)\\]\\((.+?)\\)";
-    static final String LINK_REPLACE = "[[$2|$1]]";
+    static final String LINK_REPLACE = "[$2 $1]";
 
     private LinkConstants() {
         //no instances allowed

--- a/md2moin-core/src/test/java/net/malanius/md2moin/core/ConverterImplTest.java
+++ b/md2moin-core/src/test/java/net/malanius/md2moin/core/ConverterImplTest.java
@@ -5,6 +5,7 @@ import net.malanius.md2moin.core.emphasis.EmphasisConverterImpl;
 import net.malanius.md2moin.core.headers.HeaderConverterImpl;
 import net.malanius.md2moin.core.lists.ListConverterImpl;
 import net.malanius.md2moin.core.tables.TableConverterImpl;
+import net.malanius.md2moin.core.links.LinkConverterImpl;
 import org.apache.commons.io.IOUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -27,7 +28,8 @@ public class ConverterImplTest {
                 new HeaderConverterImpl(),
                 new ListConverterImpl(),
                 new CodeBlockConverterImpl(),
-                new TableConverterImpl());
+                new TableConverterImpl(),
+                new LinkConverterImpl());
     }
 
     @After

--- a/md2moin-core/src/test/java/net/malanius/md2moin/core/links/LinkConverterImplTest.java
+++ b/md2moin-core/src/test/java/net/malanius/md2moin/core/links/LinkConverterImplTest.java
@@ -24,8 +24,8 @@ public class LinkConverterImplTest {
     public void convertLink() {
         String input = "This is some text with [Example](https://example.com) link. And yet [another](www.example.com) one.\n"
                 + "This is [link](http://example.com) on another line.";
-        String expected = "This is some text with [[https://example.com|Example]] link. And yet [[www.example.com|another]] one.\n"
-                + "This is [[http://example.com|link]] on another line.";
+        String expected = "This is some text with [https://example.com Example] link. And yet [www.example.com another] one.\n"
+                + "This is [http://example.com link] on another line.";
 
         assertEquals(expected, converter.convertLink(input));
     }

--- a/md2moin-core/src/test/resources/test.moin
+++ b/md2moin-core/src/test/resources/test.moin
@@ -49,8 +49,8 @@ And yet --(another)-- occurrence.
 
 == Links ==
 
-This is some text with [Example](https://example.com) link. And yet [another](www.example.com) one.
-This is [link](http://example.com) on another line.
+This is some text with [https://example.com Example] link. And yet [www.example.com another] one.
+This is [http://example.com link] on another line.
 
 == Code blocks ==
 


### PR DESCRIPTION
thanks for putting this rather obscure tool out there and making it easy to use.
parsing links was mostly implemented, but not enabled.

I changed the output link syntax from `[[url|alias]]` to `[url alias]` - this is what my moinmoin wiki documents and accepts as correct link syntax. I just noticed that this is not what the [official wiki documents](https://moinmo.in/HelpOnMoinWikiSyntax#External_Links) - not sure where that syntax change originates..

edit: oof, moin [apparently changed link syntax in 1.6.0](https://github.com/moinwiki/moin-1.9/blob/fc8fc67a765bc5468795bcfde30561cb7e110bdb/docs/CHANGES#L2111-L2112) (2007) - we're running something older..
